### PR TITLE
let white video plugin follow calibrated time

### DIFF
--- a/packages/oss-upload-button/src/index.tsx
+++ b/packages/oss-upload-button/src/index.tsx
@@ -192,7 +192,6 @@ export default class OssUploadButton extends React.Component<OssUploadButtonProp
                     originY: -135,
                     width: 480,
                     height: 270,
-                    selectable: false,
                     attributes: { src: url },
                 });
             }

--- a/packages/white-video-plugin/package.json
+++ b/packages/white-video-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netless/white-video-plugin2",
-    "version": "2.0.4",
+    "version": "2.1.0",
     "description": "a video plugin for white-web-sdk which can play video in whiteboard room and sync to everyone in room",
     "private": false,
     "main": "dist/index.js",
@@ -17,9 +17,9 @@
     "license": "MIT",
     "dependencies": {},
     "peerDependencies": {
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0",
-        "white-web-sdk": "^2.5.9"
+        "react": "^16.8.0 || ^17",
+        "react-dom": "^16.8.0 || ^17",
+        "white-web-sdk": "^2.13.8"
     },
     "devDependencies": {
         "@types/node": "^11.12.2",

--- a/packages/white-video-plugin/src/WhiteVideoPlugin.tsx
+++ b/packages/white-video-plugin/src/WhiteVideoPlugin.tsx
@@ -68,8 +68,9 @@ class WhiteVideoPluginImpl extends Component<WhiteVideoPluginImplProps> {
     }
 
     timestamp = () => {
+        const { room } = this.props;
         const player = this.player.current!;
-        return { currentTime: player.currentTime, hostTime: Date.now() };
+        return { currentTime: player.currentTime, hostTime: room?.calibrationTimestamp || Date.now() };
     };
 
     setupHost() {
@@ -109,7 +110,7 @@ class WhiteVideoPluginImpl extends Component<WhiteVideoPluginImplProps> {
     }
 
     setupNonHost() {
-        const { plugin } = this.props;
+        const { plugin, room } = this.props;
         const player = this.player.current!;
         // n.b. reaction() 对 plugin.attributes 不起效，sdk 总是更新整个 attributes
         //      因此这里使用 autorun 和自己写的 changed() 检查变化
@@ -128,7 +129,7 @@ class WhiteVideoPluginImpl extends Component<WhiteVideoPluginImplProps> {
                 player.muted = plugin.attributes.muted;
             }
             if (this.changedMap.changed("time", [currentTime, hostTime]) && hostTime > 0) {
-                let now = Date.now();
+                let now = room?.calibrationTimestamp || Date.now();
                 if (this.props.player) {
                     now = this.props.player.beginTimestamp + playerTimestamp;
                 }

--- a/whiteboard/package.json
+++ b/whiteboard/package.json
@@ -42,7 +42,7 @@
         "react-router-dom": "^4.3.1",
         "uuid": "^8.3.2",
         "video.js": "^7.11.8",
-        "white-web-sdk": "2.13.6"
+        "white-web-sdk": "2.13.8"
     },
     "devDependencies": {
         "@types/ali-oss": "^6.0.7",

--- a/whiteboard/package.json
+++ b/whiteboard/package.json
@@ -25,7 +25,7 @@
         "@netless/white-audio-plugin": "^1.2.23",
         "@netless/white-audio-plugin2": "^2.0.4",
         "@netless/white-video-plugin": "^1.2.23",
-        "@netless/white-video-plugin2": "^2.0.4",
+        "@netless/white-video-plugin2": "^2.1.0",
         "@netless/zip": "^0.0.6",
         "@netless/zoom-controller": "^0.1.1",
         "antd": "^4.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12209,10 +12209,10 @@ which@^1.2.14, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-white-web-sdk@2.13.6:
-  version "2.13.6"
-  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.13.6.tgz#8e45d022af3deba20412081565d72cfaa6e522da"
-  integrity sha512-aeARwxMKP5gnVWbLLjbw+R5yuCzst9UVyeede1SdqW9wCT4UA2o1tXH3hSeTc+NRjGn8C8d155osbJ+1/YI8fw==
+white-web-sdk@2.13.8:
+  version "2.13.8"
+  resolved "https://registry.npmjs.org/white-web-sdk/-/white-web-sdk-2.13.8.tgz#bf5b328b4b8fda657a90bd8be3b3d86add0c93a8"
+  integrity sha512-MwqKclYDa6c3iywDASzioo8kmMZNzeBvXgLWkpVxu6O+InxOKNLOcjkZx8ruNoxGZjzbAiUC78n9O5+AD9jxEw==
   dependencies:
     "@netless/canvas-polyfill" "^0.0.4"
     atob "^2.1.0"


### PR DESCRIPTION
- refactor(white-video-plugin2): support `calibrationTimestamp`
- fix(oss-upload-button): remove `selectable: false` in inserting video plugin
- chore: bump version
